### PR TITLE
Fixed project renaming scripts and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ rename-provider:
 	@./hack/rename-provider ${PROVIDER_NAME}
 
 .PHONY: rename-project
-rename-provider:
+rename-project:
 	@./hack/rename-project ${PROJECT_NAME}
 
 #########################################

--- a/hack/rename-project
+++ b/hack/rename-project
@@ -16,8 +16,8 @@
 
 project_name=$1
 
-sed -i '' "s/gardener/$project_name/g" pkg/sampleprovider/driver.go
-sed -i '' "s/gardener/$project_name/g" pkg/sampleprovider/machineserver.go
-sed -i '' "s/gardener/$project_name/g" app/controller/main.go
+sed -i "s/gardener/$project_name/g" pkg/sampleprovider/driver.go
+sed -i "s/gardener/$project_name/g" pkg/sampleprovider/machineserver.go
+sed -i "s/gardener/$project_name/g" app/controller/main.go
 
 echo "Rename project from gardener to $project_name."

--- a/hack/rename-provider
+++ b/hack/rename-provider
@@ -17,15 +17,15 @@
 normal_case=$1
 small_case=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
-sed -i '' "s/sampleprovider/$small_case/g" app/controller/main.go
-sed -i '' "s/sampleprovider/$small_case/g" pkg/sampleprovider/driver.go
-sed -i '' "s/sampleprovider/$small_case/g" pkg/sampleprovider/machineserver.go
-sed -i '' "s/sampleprovider/$small_case/g" Makefile
-sed -i '' "s/sampleprovider/$small_case/g" README.md
-sed -i '' "s/SampleProvider/$normal_case/g" pkg/sampleprovider/apis/provider-spec.go
+sed -i "s/sampleprovider/$small_case/g" app/controller/main.go
+sed -i "s/sampleprovider/$small_case/g" pkg/sampleprovider/driver.go
+sed -i "s/sampleprovider/$small_case/g" pkg/sampleprovider/machineserver.go
+sed -i "s/sampleprovider/$small_case/g" Makefile
+sed -i "s/sampleprovider/$small_case/g" README.md
+sed -i "s/SampleProvider/$normal_case/g" pkg/sampleprovider/apis/provider-spec.go
 
-sed -i '' "s/SampleProvider/$normal_case/g" hack/rename-provider
-sed -i '' "s/sampleprovider/$small_case/g" hack/rename-provider
+sed -i "s/SampleProvider/$normal_case/g" hack/rename-provider
+sed -i "s/sampleprovider/$small_case/g" hack/rename-provider
 
 mv pkg/sampleprovider pkg/$small_case
 


### PR DESCRIPTION
For me on MacOS I needed to make those changes to make the renaming for project/provider work.